### PR TITLE
Use Get-CimInstance when wmic is not present

### DIFF
--- a/tgpy/main.py
+++ b/tgpy/main.py
@@ -62,7 +62,10 @@ def create_client():
             )
         except FileNotFoundError:
             device_model = ' '.join(
-                subprocess.check_output(['powershell', 'Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer,Model | Format-List'])
+                subprocess.check_output([
+                    'powershell',
+                    'Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer,Model | Format-List'
+                ])
                 .decode()
                 .replace('Manufacturer : ', '')
                 .replace('Model        : ', '')

--- a/tgpy/main.py
+++ b/tgpy/main.py
@@ -52,13 +52,23 @@ def create_client():
             subprocess.check_output('sysctl -n hw.model'.split(' ')).decode().strip()
         )
     elif sys.platform == 'win32':
-        device_model = ' '.join(
-            subprocess.check_output('wmic computersystem get manufacturer,model')
-            .decode()
-            .replace('Manufacturer', '')
-            .replace('Model', '')
-            .split()
-        )
+        try:
+            device_model = ' '.join(
+                subprocess.check_output('wmic computersystem get manufacturer,model')
+                .decode()
+                .replace('Manufacturer', '')
+                .replace('Model', '')
+                .split()
+            )
+        except FileNotFoundError:
+            device_model = ' '.join(
+                subprocess.check_output(['powershell', 'Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer,Model | Format-List'])
+                .decode()
+                .replace('Manufacturer : ', '')
+                .replace('Model        : ', '')
+                .strip()
+                .splitlines()
+            )
 
     client = TelegramClient(
         str(SESSION_FILENAME),

--- a/tgpy/main.py
+++ b/tgpy/main.py
@@ -64,7 +64,7 @@ def create_client():
             device_model = ' '.join(
                 subprocess.check_output([
                     'powershell',
-                    'Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer,Model | Format-List'
+                    'Get-CimInstance Win32_ComputerSystem | Select-Object Manufacturer,Model | Format-List',
                 ])
                 .decode()
                 .replace('Manufacturer : ', '')


### PR DESCRIPTION
On newer Windows versions, WMIC is deprecated and has been removed, preventing TGPy from starting. I've implemented exception handling and an alternative method using the *Get-CimInstance* API to gather device data.